### PR TITLE
Add Mentor ApplicationUser include and fix redundant Mentee include in BookingService

### DIFF
--- a/MentorHup/APPLICATION/Service/Booking/BookingService.cs
+++ b/MentorHup/APPLICATION/Service/Booking/BookingService.cs
@@ -17,8 +17,9 @@ public class BookingService(ApplicationDbContext context, IStripeService stripeS
     {
         var booking = await context.Bookings
             .Include(b => b.Mentee)
-                .ThenInclude(m => m.ApplicationUser)
+                .ThenInclude(mentee => mentee.ApplicationUser)
             .Include(b => b.Mentor)
+                .ThenInclude(mentor => mentor.ApplicationUser)
             .Include(b => b.MentorAvailability)
             .Include(b => b.Payment)
             .FirstOrDefaultAsync(b => b.Id == bookingId);
@@ -164,7 +165,6 @@ public class BookingService(ApplicationDbContext context, IStripeService stripeS
         var query = context.Bookings
             .Include(b => b.Mentor)
             .Include(b => b.Mentee)
-                .ThenInclude(ment => ment.ApplicationUser)
             .AsQueryable();
 
         if (role == "Mentee")


### PR DESCRIPTION
## Description  

This update improves the `BookingService` by ensuring that both **Mentee** and **Mentor** related `ApplicationUser` entities are properly included when retrieving bookings.  

### Changes  
- **Added**:  
  - `ThenInclude(mentor => mentor.ApplicationUser)` to load the Mentor’s ApplicationUser details.  

- **Removed**:  
  - Redundant `ThenInclude` for Mentee’s ApplicationUser in `GetBookingsForUserAsync`.  

### Purpose  
- Prevent potential `NullReferenceException` when accessing Mentor’s email during booking cancellation.  
- Ensure consistent data loading for both Mentee and Mentor.  
- Clean up redundant includes for better readability and maintainability.  

### Impact  
This change ensures that email notifications sent to both Mentees and Mentors during booking cancellation will always have the necessary user details available.  

### Testing Notes  
1. **Cancel Booking (as Mentee):**  
   - Book a session as a mentee.  
   - Cancel the booking.  
   - Verify that the cancellation email is received by both mentee and mentor, and that emails include correct names and addresses.  

2. **Cancel Booking (as Mentor):**  
   - Mentor cancels a session.  
   - Ensure that both parties receive emails without errors.  

3. **Database Validation:**  
   - Confirm that `Mentor.ApplicationUser` and `Mentee.ApplicationUser` are loaded in queries without triggering lazy loading or null references.  

4. **Regression Check:**  
   - Fetch bookings list (GetBookingsForUserAsync) and confirm no duplicate or redundant includes cause issues.  